### PR TITLE
update 11.26

### DIFF
--- a/camera_app/Buttons/ChangeBtns/Change2ndCameraBtn.js
+++ b/camera_app/Buttons/ChangeBtns/Change2ndCameraBtn.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+import { Entypo } from '@expo/vector-icons';
+
+const Next = ({ onPress }) => (
+  <TouchableOpacity onPress={onPress}>
+    <Entypo name="arrow-bold-right" color="black" size={60} />
+  </TouchableOpacity>
+);
+
+export default Next;

--- a/camera_app/api.js
+++ b/camera_app/api.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { useState } from 'react';
 import { Alert } from 'react-native';
 
-const URL = 'http://222.106.22.110:45045/let_me_shine';
+const URL = 'http://121.138.83.1:45045/let_me_shine';
 
 let tempResult = [];
 
@@ -33,7 +33,7 @@ const getResultURL = async (url) => {
   }
 };
 
-export const imageTransfer = async (photo, sex) => {
+export const imageTransfer = async (firstPhoto, secondPhoto, sex) => {
   try {
     console.log('[1] Post Start!');
     const config = {
@@ -45,7 +45,16 @@ export const imageTransfer = async (photo, sex) => {
     };
 
     await axios
-      .post(URL, { label: 'Image', origin: photo, gender: sex }, config) // 해당 URL로 POST
+      .post(
+        URL,
+        {
+          label: 'Image',
+          origin: firstPhoto,
+          custom: secondPhoto,
+          gender: sex,
+        },
+        config
+      ) // 해당 URL로 POST
       .then((res) => getResultURL(res.data))
       // POST의 결과(res)로부터 모델 결과 위치(res.data) 얻음
       // 이를 getResultURL 함수로 보낸다.


### PR DESCRIPTION
2인용 카메라 아이콘 및 관련 flow 해결
각 버튼 눌렀을때 해당되는 스크린 이동이나
스크린 이동시, 변화되는 버튼에 적용

가끔 발생하는 오류로는
저장이나 공유 버튼 누른 뒤
아이콘이 1인용으로 바뀌면서 2인용 기능이 적용되지 않다가
앨범에서 한번 취소를 누르거나 사진을 찍고 다시 취소를 눌러서
카메라 메인 화면으로 나가면 동작됨

앱으로 만들어서 같이 오류가 발생하는지 확인해보는게 중요할 듯